### PR TITLE
Handle When Time Is "Noon"

### DIFF
--- a/src/json-schedule-generator/json_schedule_generator.py
+++ b/src/json-schedule-generator/json_schedule_generator.py
@@ -145,6 +145,8 @@ class JsonScheduleGenerator:
 
     @staticmethod
     def _format_time(*, time: str) -> str:
+        if time.lower() == "noon":
+            return "12:00"
         time = time.replace("a.m.", "AM").replace("p.m.", "PM")
         time_obj = datetime.datetime.strptime(time, "%I:%M %p")
         return time_obj.strftime("%H:%M")


### PR DESCRIPTION
Solves this [error](https://github.com/RamVasuthevan/island-ferry-tracker/actions/runs/10967993287/job/30458657946):
```
Traceback (most recent call last):
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 189, in <module>
    run()
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 1[74](https://github.com/RamVasuthevan/island-ferry-tracker/actions/runs/10967993287/job/30458657946#step:4:75), in run
    schedules = JsonScheduleGenerator.create_schedules(schedules_soup=soup)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 36, in create_schedules
    JsonScheduleGenerator._create_schedule(schedule_soup=schedule_soup)
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 60, in _create_schedule
    JsonScheduleGenerator._create_location_schedule(
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 124, in _create_location_schedule
    JsonScheduleGenerator._format_time(time=row.contents[3].contents[0])
  File "/home/runner/work/island-ferry-tracker/island-ferry-tracker/src/json-schedule-generator/json_schedule_generator.py", line 149, in _format_time
    time_obj = datetime.datetime.strptime(time, "%I:%M %p")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/_strptime.py", line 554, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/_strptime.py", line 333, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'Noon' does not match format '%I:%M %p'
```